### PR TITLE
📦 Fix React dependencies

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "next": "latest",
     "next-routes": "^1.4.1",
     "prop-types": "15.6.1",
-    "react": "16.2.0",
+    "react": "^16.8.2",
     "react-apollo": "2.1.0",
     "react-dom": "16.2.0",
     "react-markdown": "^3.3.2"


### PR DESCRIPTION
The latest master branch of graphql-workshop gives me an annoying message about peer dependencies and I can't run it because if complains `React.createContext` does not exist.

I was able to fix it changing the version of `react` in `web/package.json`. Not sure if this fix correct because I'm a JS n00b, but well, it works.